### PR TITLE
added support live debugger when gtm previewer is turned on

### DIFF
--- a/template.js
+++ b/template.js
@@ -6,11 +6,19 @@ const injectScript = require('injectScript');
 const getTimestamp = require('getTimestamp');
 const Math = require('Math');
 const getType = require('getType');
+const getContainerVersion = require('getContainerVersion');
 
 // Unique identifier for BillyPix, replace 'ID-XXXXXXXX' with actual ID
 const billyPixId = data.trackingID;
 const cdnEndpoint = data.useStaging ? 'https://staging.bgmin.cdn.billygrace.com' : 'https://bgmin.cdn.billygrace.com';
 const billyFunctionName = data.useStaging ? 'StagBillyPix' : 'BillyPix';
+
+// Determine if live debugging needs to be turned on
+const cv = getContainerVersion();
+
+// Difference preview and debug: https://support.google.com/tagmanager/answer/6107056
+// TLDR: Both are set to true when you are debugging your container
+const isGtmDebugSession = cv.debugMode && cv.previewMode;
 
 // Tracking ID needs to be set
 if (getType(billyPixId) === 'undefined') {
@@ -36,7 +44,7 @@ if (data.isDebug){
 
 function successfullyInjectedScript(){
   // Initialize BillyPix so the Tracking ID is set on the web page
-  BillyPix('init', billyPixId);
+  BillyPix('init', billyPixId, {debug: isGtmDebugSession});
   
   // Debug to see if correct
   if (data.isDebug){
@@ -57,7 +65,6 @@ function successfullyInjectedScript(){
   // Finish with the success handler to close this function
   return data.gtmOnSuccess();
 }
-
 
 // Inject the BillyPix script
 injectScript(scriptUrl, successfullyInjectedScript(), data.gtmOnFailure, scriptUrl);

--- a/template.tpl
+++ b/template.tpl
@@ -112,11 +112,19 @@ const injectScript = require('injectScript');
 const getTimestamp = require('getTimestamp');
 const Math = require('Math');
 const getType = require('getType');
+const getContainerVersion = require('getContainerVersion');
 
 // Unique identifier for BillyPix, replace 'ID-XXXXXXXX' with actual ID
 const billyPixId = data.trackingID;
 const cdnEndpoint = data.useStaging ? 'https://staging.bgmin.cdn.billygrace.com' : 'https://bgmin.cdn.billygrace.com';
 const billyFunctionName = data.useStaging ? 'StagBillyPix' : 'BillyPix';
+
+// Determine if live debugging needs to be turned on
+const cv = getContainerVersion();
+
+// Difference preview and debug: https://support.google.com/tagmanager/answer/6107056
+// TLDR: Both are set to true when you are debugging your container
+const isGtmDebugSession = cv.debugMode && cv.previewMode;
 
 // Tracking ID needs to be set
 if (getType(billyPixId) === 'undefined') {
@@ -142,7 +150,7 @@ if (data.isDebug){
 
 function successfullyInjectedScript(){
   // Initialize BillyPix so the Tracking ID is set on the web page
-  BillyPix('init', billyPixId);
+  BillyPix('init', billyPixId, {debug: isGtmDebugSession});
   
   // Debug to see if correct
   if (data.isDebug){
@@ -476,6 +484,16 @@ ___WEB_PERMISSIONS___
     },
     "clientAnnotations": {
       "isEditedByUser": true
+    },
+    "isRequired": true
+  },
+  {
+    "instance": {
+      "key": {
+        "publicId": "read_container_data",
+        "versionId": "1"
+      },
+      "param": []
     },
     "isRequired": true
   }


### PR DESCRIPTION
* Using the build in [getContainerVersion](https://developers.google.com/tag-platform/tag-manager/templates/api#getcontainerversion) to retrieve container state
   - Used to determine if the preview mode with debugger is turned on
* When this happens the backend will not process the data and make it available in our own live debugger