### PR TITLE
Sequencing init copy non reference fix

### DIFF
--- a/template.js
+++ b/template.js
@@ -2,7 +2,6 @@
 const log = require('logToConsole');
 const JSON = require('JSON');
 const setInWindow = require('setInWindow');
-const createQueue = require('createQueue');
 const getTimestamp = require('getTimestamp');
 const Math = require('Math');
 const injectScript = require('injectScript');
@@ -38,21 +37,23 @@ const isGtmDebugSession = cv.debugMode && cv.previewMode;
 
 
 // Optionally log messages when debug is enabled
-function debugLog(message) {
-  if (data.isDebug) {
+function debugLog(message, isError = false) {
+  if (isError == true){
+    log('[BG Conf Tag]', message);
+  }else if (data.isDebug) {
     log('[BG Conf Tag]', message);
   }
 }
 
 // Tracking ID needs to be set
 if (getType(billyPixId) === 'undefined') {
-  log('Error: Billy Grace Pixel not configured correctly. No Tracking ID is set.');
+  debugLog('Error: Billy Grace Pixel not configured correctly. No Tracking ID is set.', true);
   return data.gtmOnFailure();
 }
 
 // Check permission to inject the script
 if (!queryPermission('inject_script', scriptUrl)) {
-  log('Error: Permission denied to inject Billy Grace Pixel script from', scriptUrl);
+  debugLog('Error: Permission denied to inject Billy Grace Pixel script from: ' + scriptUrl, true);
   data.gtmOnFailure();
   return;
 }
@@ -114,7 +115,7 @@ function addMainFunctionToWindow() {
   
 }
 
-// Check if BillyPix already exists - same as original snippet's first check
+// Check if BillyPix already exists, mimics the original snippet's first check
 const existingFunc = copyFromWindow(billyFunctionName);
 if (!existingFunc) {
   addMainFunctionToWindow();
@@ -132,10 +133,14 @@ if (getType(data.overrideCookiedomain) !== 'undefined') {
 const processFunc = copyFromWindow(billyFunctionName + '.process');
 
 
-// CDN already loaded -- call .process directly, bypassing the stub
+// CDN already loaded: call .process directly, bypassing the stub
 if (processFunc && getType(processFunc) === 'function') {
   debugLog('CDN already loaded, calling .process directly');
+  
+  // Setup the initialiazation with any given extra options
   callInWindow(billyFunctionName + '.process', 'init', billyPixId, extraInitOptions);
+
+  // Make sure the pageload event gets triggered 
   if (data.noPageloadEvent === false) {
     if (data.pageloadEventID) {
       callInWindow(billyFunctionName + '.process', 'event', 'pageload', {event_id: data.pageloadEventID});
@@ -144,14 +149,19 @@ if (processFunc && getType(processFunc) === 'function') {
     }
   }
 } 
-// CDN not loaded yet -- write events directly into the queue
+// CDN not loaded yet: write events directly into the queue
 else {
   debugLog('CDN not loaded yet, writing events to queue');
+
+  // Grab a copy (non reference) from an existing queue object to add to 
   const currentQueue = copyFromWindow(billyFunctionName + '.queue');
+  
   if (currentQueue && getType(currentQueue) === 'array') {
 
     // Add init and initial pageload event to the queue (if required)
     currentQueue.push(['init', billyPixId, extraInitOptions]);
+    
+    // Make sure the pageload event gets triggered 
     if (data.noPageloadEvent === false) {
       if (data.pageloadEventID) {
         currentQueue.push(['event', 'pageload', {event_id: data.pageloadEventID}]);
@@ -163,7 +173,7 @@ else {
     // Need to overwrite the queue with the new one as its just a copy of the original
     setInWindow(billyFunctionName + '.queue', currentQueue, true);
   }else{
-    debugLog('Queue does not exist, something went wrong');
+    debugLog('[BG Conf Tag] Error: Queue does not exist so can\'t trigger "pageload" event..', true);
   }
 }
 
@@ -173,7 +183,7 @@ function onScriptLoaded() {
 }
 
 function onScriptFailed() {
-  log('Error: Billy Grace Pixel script failed to load from ' + scriptUrl);
+  debugLog('Error: Billy Grace Pixel script failed to load from ' + scriptUrl, true);
   return data.gtmOnFailure();
 }
 

--- a/template.js
+++ b/template.js
@@ -37,25 +37,27 @@ const isGtmDebugSession = cv.debugMode && cv.previewMode;
 
 
 // Optionally log messages when debug is enabled
-function debugLog(message, isError = false) {
-  if (isError == true){
-    log('[BG Conf Tag]', message);
-  }else if (data.isDebug) {
+function debugLog(message) {
+  if (data.isDebug) {
     log('[BG Conf Tag]', message);
   }
 }
+// For all error messages the end user should see
+function errorLog(message) {
+   log('[BG Conf Tag] Error: ', message);
+}
+
 
 // Tracking ID needs to be set
 if (getType(billyPixId) === 'undefined') {
-  debugLog('Error: Billy Grace Pixel not configured correctly. No Tracking ID is set.', true);
+  errorLog('Billy Grace Pixel not configured correctly. No Tracking ID is set.');
   return data.gtmOnFailure();
 }
 
 // Check permission to inject the script
 if (!queryPermission('inject_script', scriptUrl)) {
-  debugLog('Error: Permission denied to inject Billy Grace Pixel script from: ' + scriptUrl, true);
-  data.gtmOnFailure();
-  return;
+  errorLog('Permission denied to inject Billy Grace Pixel script from: ' + scriptUrl);
+  return data.gtmOnFailure();
 }
 
 
@@ -115,6 +117,16 @@ function addMainFunctionToWindow() {
   
 }
 
+function onScriptLoaded() {
+  debugLog('Script loaded successfully');
+  return data.gtmOnSuccess();
+}
+
+function onScriptFailed() {
+  debugLog('Error: Billy Grace Pixel script failed to load from ' + scriptUrl, true);
+  return data.gtmOnFailure();
+}
+
 // Check if BillyPix already exists, mimics the original snippet's first check
 const existingFunc = copyFromWindow(billyFunctionName);
 if (!existingFunc) {
@@ -148,15 +160,18 @@ if (processFunc && getType(processFunc) === 'function') {
       callInWindow(billyFunctionName + '.process', 'event', 'pageload');
     }
   }
+
+  // Complete the tag as required events have been fired directly at .process 
+  return data.gtmOnSuccess();
 } 
 // CDN not loaded yet: write events directly into the queue
 else {
-  debugLog('CDN not loaded yet, writing events to queue');
 
   // Grab a copy (non reference) from an existing queue object to add to 
   const currentQueue = copyFromWindow(billyFunctionName + '.queue');
   
   if (currentQueue && getType(currentQueue) === 'array') {
+    debugLog('CDN not loaded yet, writing events to queue');
 
     // Add init and initial pageload event to the queue (if required)
     currentQueue.push(['init', billyPixId, extraInitOptions]);
@@ -173,19 +188,10 @@ else {
     // Need to overwrite the queue with the new one as its just a copy of the original
     setInWindow(billyFunctionName + '.queue', currentQueue, true);
   }else{
-    debugLog('[BG Conf Tag] Error: Queue does not exist so can\'t trigger "pageload" event..', true);
+    errorLog('Queue does not exist so can\'t add "pageload" event to queue..');
   }
-}
 
-function onScriptLoaded() {
-  debugLog('Script loaded successfully');
-  return data.gtmOnSuccess();
+  // Load the script into the website and complete the tag when its loaded
+  debugLog('Loading script from: ' + scriptUrl);
+  injectScript(scriptUrl, onScriptLoaded, onScriptFailed, scriptUrl);
 }
-
-function onScriptFailed() {
-  debugLog('Error: Billy Grace Pixel script failed to load from ' + scriptUrl, true);
-  return data.gtmOnFailure();
-}
-
-debugLog('Loading script from: ' + scriptUrl);
-injectScript(scriptUrl, onScriptLoaded, onScriptFailed, scriptUrl);

--- a/template.js
+++ b/template.js
@@ -1,65 +1,147 @@
 // GTM API functions required
 const log = require('logToConsole');
-const JSON = require('JSON');
+const copyFromWindow = require('copyFromWindow');
+const getType = require('getType');
+const Object = require('Object');
 const setInWindow = require('setInWindow');
-const createQueue = require('createQueue');
 const getTimestamp = require('getTimestamp');
 const Math = require('Math');
 const injectScript = require('injectScript');
-const copyFromWindow = require('copyFromWindow');
-const getType = require('getType');
+const JSON = require('JSON');
 const getContainerVersion = require('getContainerVersion');
 const queryPermission = require('queryPermission');
 
 /**
- * Billy Grace - Configuration Web Pixel Template
- * 
- * This handles initialization, script loading, and the event tracking code
- * in accordance with the original implementation.
+ * Billy Grace Event Tag for GTM
+ * It requires the Billy Grace Configuration tag to be run first.
  */
 
-// Unique identifier for the client's account
+// Unique identifier for BillyPix, replace 'ID-XXXXXXXX' with actual ID
 const billyPixId = data.trackingID;
-const cdnEndpoint = data.useStaging ? 'https://staging.bgmin.cdn.billygrace.com' : 'https://bgmin.cdn.billygrace.com';
 const billyFunctionName = data.useStaging ? 'StagBillyPix' : 'BillyPix';
 
-// Calculate cache busting value
-const secondsBuste = 30*1000; // 6 hours in milliseconds
-const epochRounded = secondsBuste * Math.ceil(getTimestamp() / secondsBuste);
-const scriptUrl = cdnEndpoint + '?t=' + epochRounded + '&v=0.2.0';
-
-// Determine if live debugging needs to be turned on
-const cv = getContainerVersion();
-
-// Difference preview and debug: https://support.google.com/tagmanager/answer/6107056
-// TLDR: Both are set to true when you are debugging your container
-const isGtmDebugSession = cv.debugMode && cv.previewMode;
-
-
-// Optionally log messages when debug is enabled
+// Conditional logging based on boolean set by implementer
 function debugLog(message) {
   if (data.isDebug) {
-    log('[BG Conf Tag]', message);
+    log('[BG Event Tag]', message);
   }
 }
 
-// Tracking ID needs to be set
-if (getType(billyPixId) === 'undefined') {
-  log('Error: Billy Grace Pixel not configured correctly. No Tracking ID is set.');
+/**
+ * Determines the event name based on user configuration
+ * @param {Object} data - The GTM tag data object
+ * @return {String} The resolved event name
+ */
+const getEventName = (data) => {
+  // Also send unknown names, as this indicates something is wrong
+  let eventName = 'unknown';
+  
+  // Standard events from dropdown
+  if (data.eventName === 'standard' && data.standardEventName) eventName = data.standardEventName;    
+
+  // Custom event name typed out by user
+  if (data.eventName === 'custom' && data.customEventName) eventName = data.customEventName;    
+  
+  // GTM Variabe as event name
+  if (data.eventName === 'variable' && data.variableEventName) eventName = data.variableEventName;    
+  
+  return eventName;
+};
+
+/**
+ * Collects all event parameters 
+ * @param {Object} data - The GTM tag data object
+ * @return {Object|String} The event parameters or empty string if none
+ */
+const getEventData = (data) => {
+  // Store extra event data
+  let customEventData = {};
+  
+  // If any extra custom parameters are set
+  if (data.extraEventParameters){
+    // If set, make sure to set in right format
+    for (let extraDataItem of data.extraEventParameters) {
+      customEventData[extraDataItem.eventParameterName] = extraDataItem.eventParameterValue;
+    }
+  }
+  
+  // If any of the values are set, then override anything we currently have
+  if (data.transaction_id) customEventData.transaction_id = data.transaction_id;
+  if (data.value) customEventData.value = data.value;
+  if (data.currency) customEventData.currency = data.currency;
+  
+  // Used for de-duplication
+  if (data.eventID) customEventData.event_id = data.eventID;
+  
+  // Just an empty string so no object parsing will happen on receival
+  if (Object.keys(customEventData).length === 0){
+     return '';
+  }
+  
+  // Prepare data to be send out
+  return customEventData;
+};
+
+// Grab all required data needed for this event
+const eventName = getEventName(data);
+const eventData = getEventData(data);
+
+// Sanity check: Fail if no event name is set
+if (eventName === 'unknown') {
+  log('[BG Event Tag] Error: No event name is set. Please select a standard event, set a custom event name, or use a variable.');
   return data.gtmOnFailure();
 }
 
-// Check permission to inject the script
-if (!queryPermission('inject_script', scriptUrl)) {
-  log('Error: Permission denied to inject Billy Grace Pixel script from', scriptUrl);
-  data.gtmOnFailure();
-  return;
+/**
+ * Checks if the Billy Grace tracking function is properly set up in the window
+ * @return {Boolean} True if BillyPix is available and valid
+ */
+function isBillyPixValid() {
+  const BillyPixFunction = copyFromWindow(billyFunctionName);
+  const existingQueue = copyFromWindow(billyFunctionName + '.queue');
+
+  // BillyPix should exist, be a function, and have an array queue
+  return BillyPixFunction && 
+         (getType(BillyPixFunction) === 'function') && 
+         (getType(existingQueue) === 'array');
+}
+
+
+/**
+ * Callback function called after script is loaded
+ * Initializes the tracking and sends the event
+ */
+function onScriptLoadedAndFireEvent() {
+  // Get the function again to ensure we have latest reference
+  const BillyPix = copyFromWindow(billyFunctionName);
+
+  if (!BillyPix) {
+    log('[BG Event Tag] Error: ' + billyFunctionName + ' not found after script load');
+    return data.gtmOnFailure();
+  }
+
+  // Determine if live debugging needs to be turned on
+  const cv = getContainerVersion();
+
+  // Difference preview and debug: https://support.google.com/tagmanager/answer/6107056
+  // TLDR: Both are set to true when you are debugging your container
+  const isGtmDebugSession = cv.debugMode && cv.previewMode;
+  
+  // Initialize BillyPix with the tracking ID
+  BillyPix('init', billyPixId, {debug: isGtmDebugSession});
+  debugLog('Successfully initialized the ' + billyFunctionName + ' for ID: ' + billyPixId);
+
+  // Fire the event
+  BillyPix('event', eventName, eventData);
+  
+  // Complete the tag
+  return data.gtmOnSuccess();
 }
 
 
 /**
  * Adds the main tracking function to the window
- * This function replicates the behavior of the original Billy Grace snippet
+ * Only called if the function doesn't already exist (backup functionality)
  */
 function addMainFunctionToWindow() {
   debugLog(billyFunctionName + ' not found, initializing...');
@@ -78,7 +160,8 @@ function addMainFunctionToWindow() {
     
     // If process method exists and is a function, pass arguments to it
     if (pixelFunc && typeof pixelFunc.process === 'function') {
-     debugLog('Processing ' + billyFunctionName + '("' + args[0] + '", "' + args[1] + '", ' +JSON.stringify(args[2] || {}) + ')');
+      debugLog('Processing ' + billyFunctionName + '("' + args[0] + '", "' + args[1] + '", ' +JSON.stringify(args[2] || {}) + ')');
+      
       // Call process safely using call instead of apply
       return pixelFunc.process(args[0], args[1], args[2]);
     } else {
@@ -88,10 +171,14 @@ function addMainFunctionToWindow() {
       // Get the queue and push to it
       const queue = copyFromWindow(billyFunctionName + '.queue');
       
-      // Add to queu for later processing when remote js arrives
+      // Add to queue for later processing when remote js arrives
       if (queue && getType(queue) === 'array') {
         queue.push(args);
+
+        // Need to overwrite the queue with the new one as its just a copy of the original
+        setInWindow(billyFunctionName + '.queue', queue, true);
       } else {
+        
         // If queue isn't available, initialize it first
         setInWindow(billyFunctionName + '.queue', [args], true);
         debugLog('Created new queue with first event');
@@ -107,66 +194,42 @@ function addMainFunctionToWindow() {
   
   // Set the timestamp
   setInWindow(billyFunctionName + '.t', getTimestamp(), true);
-  
 }
 
-// Check if BillyPix already exists - same as original snippet's first check
-const existingFunc = copyFromWindow(billyFunctionName);
-if (!existingFunc) {
-  addMainFunctionToWindow();
-} else {
-  debugLog(billyFunctionName + ' already exists in window, using existing implementation');
-}
 
-/**
- * Callback function when script is successfully loaded
- * Initializes the pixel and triggers page view if configured
- */
-function onScriptLoaded() {
-  // Get the function again to ensure we have latest reference
-  const BillyPix = copyFromWindow(billyFunctionName);
-
-  if (!BillyPix) {
-    log('Error: ' + billyFunctionName + ' not found after script load');
-    return data.gtmOnFailure();
-  }
+// Sanity check: BillyPix needs to be available
+if (isBillyPixValid()) {
+    // BillyPix is already available and valid - just fire the event
+    debugLog('BillyPix reference exists in window');
   
-  // Extra options for this pixel session
-  let extraInitOptions = {debug: isGtmDebugSession};
+    // Grab the existing function
+    const BillyPix = copyFromWindow(billyFunctionName);
+
+    // Fire the event
+    BillyPix('event', eventName, eventData);
     
-  // Optionally check the cookie domain needs to be overwritten
-  if (getType(data.overrideCookiedomain) !== 'undefined') {
-    extraInitOptions.cookie_domain = data.overrideCookiedomain;
-  }
+    // Complete the tag
+    data.gtmOnSuccess();
+}else{
+    // Make it clear they the user messed up
+    log('[BG Event Tag] Warning: ' + billyFunctionName + ' not available in window, make sure to first run the "Billy Grace - Web Configuration" tag. For now we are still loading it, but this can lead to performance issued');
 
-  // Initialize BillyPix with the tracking ID
-  BillyPix('init', billyPixId, extraInitOptions);
-  
-  // By default unchecked, meaning we send out the pageload event
-  if (data.noPageloadEvent === false){
-     
-    // Event id is used for de-duplication
-    if (data.pageloadEventID){
-       BillyPix('event', 'pageload', {event_id: data.pageloadEventID});
-    }else{
-       BillyPix('event', 'pageload');
+    // The backup functionality to add the BillyPix object if the sequencing was off
+    // Can be added to the window before loading the js bundle
+    addMainFunctionToWindow();
+
+    // Calculate cache busting value
+    const secondsBuste = 30*1000; // 6 hours in milliseconds
+    const epochRounded = secondsBuste * Math.ceil(getTimestamp() / secondsBuste);
+    const cdnEndpoint = data.useStaging ? 'https://staging.bgmin.cdn.billygrace.com' : 'https://bgmin.cdn.billygrace.com';
+    const scriptUrl = cdnEndpoint + '?t=' + epochRounded + '&v=0.2.0';
+
+    // Check permissions for script injection
+    if (!queryPermission('inject_script', scriptUrl)) {
+      log('[BG Event Tag] Error: Permission denied to inject script from ' + scriptUrl);
+      return data.gtmOnFailure();
     }
-  }
-  
-  // Finish with the success handler to close this function
-  return data.gtmOnSuccess();
+
+    // Inject the BillyPix script
+    injectScript(scriptUrl, onScriptLoadedAndFireEvent, data.gtmOnFailure, scriptUrl);  
 }
-
-/**
- * Callback function when script fails to load
- */
-function onScriptFailed() {
-  log('Error: Billy Grace Pixel script failed to load from ' + scriptUrl);
-  return data.gtmOnFailure();
-}
-
-// Log script loading
-debugLog('Loading script from: ' + scriptUrl);
-
-// Inject the script
-injectScript(scriptUrl, onScriptLoaded, onScriptFailed, scriptUrl);

--- a/template.js
+++ b/template.js
@@ -1,147 +1,66 @@
 // GTM API functions required
 const log = require('logToConsole');
-const copyFromWindow = require('copyFromWindow');
-const getType = require('getType');
-const Object = require('Object');
+const JSON = require('JSON');
 const setInWindow = require('setInWindow');
+const createQueue = require('createQueue');
 const getTimestamp = require('getTimestamp');
 const Math = require('Math');
 const injectScript = require('injectScript');
-const JSON = require('JSON');
+const callInWindow = require('callInWindow');
+const copyFromWindow = require('copyFromWindow');
+const getType = require('getType');
 const getContainerVersion = require('getContainerVersion');
 const queryPermission = require('queryPermission');
 
 /**
- * Billy Grace Event Tag for GTM
- * It requires the Billy Grace Configuration tag to be run first.
+ * Billy Grace - Configuration Web Pixel Template
+ * 
+ * This handles initialization, script loading, and the event tracking code
+ * in accordance with the original implementation.
  */
 
-// Unique identifier for BillyPix, replace 'ID-XXXXXXXX' with actual ID
+// Unique identifier for the client's account
 const billyPixId = data.trackingID;
+const cdnEndpoint = data.useStaging ? 'https://staging.bgmin.cdn.billygrace.com' : 'https://bgmin.cdn.billygrace.com';
 const billyFunctionName = data.useStaging ? 'StagBillyPix' : 'BillyPix';
 
-// Conditional logging based on boolean set by implementer
+// Calculate cache busting value
+const secondsBuste = 30*1000; // 6 hours in milliseconds
+const epochRounded = secondsBuste * Math.ceil(getTimestamp() / secondsBuste);
+const scriptUrl = cdnEndpoint + '?t=' + epochRounded + '&v=0.2.0';
+
+// Determine if live debugging needs to be turned on
+const cv = getContainerVersion();
+
+// Difference preview and debug: https://support.google.com/tagmanager/answer/6107056
+// TLDR: Both are set to true when you are debugging your container
+const isGtmDebugSession = cv.debugMode && cv.previewMode;
+
+
+// Optionally log messages when debug is enabled
 function debugLog(message) {
   if (data.isDebug) {
-    log('[BG Event Tag]', message);
+    log('[BG Conf Tag]', message);
   }
 }
 
-/**
- * Determines the event name based on user configuration
- * @param {Object} data - The GTM tag data object
- * @return {String} The resolved event name
- */
-const getEventName = (data) => {
-  // Also send unknown names, as this indicates something is wrong
-  let eventName = 'unknown';
-  
-  // Standard events from dropdown
-  if (data.eventName === 'standard' && data.standardEventName) eventName = data.standardEventName;    
-
-  // Custom event name typed out by user
-  if (data.eventName === 'custom' && data.customEventName) eventName = data.customEventName;    
-  
-  // GTM Variabe as event name
-  if (data.eventName === 'variable' && data.variableEventName) eventName = data.variableEventName;    
-  
-  return eventName;
-};
-
-/**
- * Collects all event parameters 
- * @param {Object} data - The GTM tag data object
- * @return {Object|String} The event parameters or empty string if none
- */
-const getEventData = (data) => {
-  // Store extra event data
-  let customEventData = {};
-  
-  // If any extra custom parameters are set
-  if (data.extraEventParameters){
-    // If set, make sure to set in right format
-    for (let extraDataItem of data.extraEventParameters) {
-      customEventData[extraDataItem.eventParameterName] = extraDataItem.eventParameterValue;
-    }
-  }
-  
-  // If any of the values are set, then override anything we currently have
-  if (data.transaction_id) customEventData.transaction_id = data.transaction_id;
-  if (data.value) customEventData.value = data.value;
-  if (data.currency) customEventData.currency = data.currency;
-  
-  // Used for de-duplication
-  if (data.eventID) customEventData.event_id = data.eventID;
-  
-  // Just an empty string so no object parsing will happen on receival
-  if (Object.keys(customEventData).length === 0){
-     return '';
-  }
-  
-  // Prepare data to be send out
-  return customEventData;
-};
-
-// Grab all required data needed for this event
-const eventName = getEventName(data);
-const eventData = getEventData(data);
-
-// Sanity check: Fail if no event name is set
-if (eventName === 'unknown') {
-  log('[BG Event Tag] Error: No event name is set. Please select a standard event, set a custom event name, or use a variable.');
+// Tracking ID needs to be set
+if (getType(billyPixId) === 'undefined') {
+  log('Error: Billy Grace Pixel not configured correctly. No Tracking ID is set.');
   return data.gtmOnFailure();
 }
 
-/**
- * Checks if the Billy Grace tracking function is properly set up in the window
- * @return {Boolean} True if BillyPix is available and valid
- */
-function isBillyPixValid() {
-  const BillyPixFunction = copyFromWindow(billyFunctionName);
-  const existingQueue = copyFromWindow(billyFunctionName + '.queue');
-
-  // BillyPix should exist, be a function, and have an array queue
-  return BillyPixFunction && 
-         (getType(BillyPixFunction) === 'function') && 
-         (getType(existingQueue) === 'array');
-}
-
-
-/**
- * Callback function called after script is loaded
- * Initializes the tracking and sends the event
- */
-function onScriptLoadedAndFireEvent() {
-  // Get the function again to ensure we have latest reference
-  const BillyPix = copyFromWindow(billyFunctionName);
-
-  if (!BillyPix) {
-    log('[BG Event Tag] Error: ' + billyFunctionName + ' not found after script load');
-    return data.gtmOnFailure();
-  }
-
-  // Determine if live debugging needs to be turned on
-  const cv = getContainerVersion();
-
-  // Difference preview and debug: https://support.google.com/tagmanager/answer/6107056
-  // TLDR: Both are set to true when you are debugging your container
-  const isGtmDebugSession = cv.debugMode && cv.previewMode;
-  
-  // Initialize BillyPix with the tracking ID
-  BillyPix('init', billyPixId, {debug: isGtmDebugSession});
-  debugLog('Successfully initialized the ' + billyFunctionName + ' for ID: ' + billyPixId);
-
-  // Fire the event
-  BillyPix('event', eventName, eventData);
-  
-  // Complete the tag
-  return data.gtmOnSuccess();
+// Check permission to inject the script
+if (!queryPermission('inject_script', scriptUrl)) {
+  log('Error: Permission denied to inject Billy Grace Pixel script from', scriptUrl);
+  data.gtmOnFailure();
+  return;
 }
 
 
 /**
  * Adds the main tracking function to the window
- * Only called if the function doesn't already exist (backup functionality)
+ * This function replicates the behavior of the original Billy Grace snippet
  */
 function addMainFunctionToWindow() {
   debugLog(billyFunctionName + ' not found, initializing...');
@@ -160,8 +79,7 @@ function addMainFunctionToWindow() {
     
     // If process method exists and is a function, pass arguments to it
     if (pixelFunc && typeof pixelFunc.process === 'function') {
-      debugLog('Processing ' + billyFunctionName + '("' + args[0] + '", "' + args[1] + '", ' +JSON.stringify(args[2] || {}) + ')');
-      
+     debugLog('Processing ' + billyFunctionName + '("' + args[0] + '", "' + args[1] + '", ' +JSON.stringify(args[2] || {}) + ')');
       // Call process safely using call instead of apply
       return pixelFunc.process(args[0], args[1], args[2]);
     } else {
@@ -171,14 +89,13 @@ function addMainFunctionToWindow() {
       // Get the queue and push to it
       const queue = copyFromWindow(billyFunctionName + '.queue');
       
-      // Add to queue for later processing when remote js arrives
+      // Add to queu for later processing when remote js arrives
       if (queue && getType(queue) === 'array') {
         queue.push(args);
 
         // Need to overwrite the queue with the new one as its just a copy of the original
         setInWindow(billyFunctionName + '.queue', queue, true);
       } else {
-        
         // If queue isn't available, initialize it first
         setInWindow(billyFunctionName + '.queue', [args], true);
         debugLog('Created new queue with first event');
@@ -194,42 +111,71 @@ function addMainFunctionToWindow() {
   
   // Set the timestamp
   setInWindow(billyFunctionName + '.t', getTimestamp(), true);
+  
 }
 
+// Check if BillyPix already exists - same as original snippet's first check
+const existingFunc = copyFromWindow(billyFunctionName);
+if (!existingFunc) {
+  addMainFunctionToWindow();
+} else {
+  debugLog(billyFunctionName + ' already exists in window, using existing implementation');
+}
 
-// Sanity check: BillyPix needs to be available
-if (isBillyPixValid()) {
-    // BillyPix is already available and valid - just fire the event
-    debugLog('BillyPix reference exists in window');
-  
-    // Grab the existing function
-    const BillyPix = copyFromWindow(billyFunctionName);
+// Build init options
+let extraInitOptions = {debug: isGtmDebugSession};
+if (getType(data.overrideCookiedomain) !== 'undefined') {
+  extraInitOptions.cookie_domain = data.overrideCookiedomain;
+}
 
-    // Fire the event
-    BillyPix('event', eventName, eventData);
-    
-    // Complete the tag
-    data.gtmOnSuccess();
-}else{
-    // Make it clear they the user messed up
-    log('[BG Event Tag] Warning: ' + billyFunctionName + ' not available in window, make sure to first run the "Billy Grace - Web Configuration" tag. For now we are still loading it, but this can lead to performance issued');
+// Check if the CDN bundle is already loaded (e.g. by the event tag)
+const processFunc = copyFromWindow(billyFunctionName + '.process');
 
-    // The backup functionality to add the BillyPix object if the sequencing was off
-    // Can be added to the window before loading the js bundle
-    addMainFunctionToWindow();
 
-    // Calculate cache busting value
-    const secondsBuste = 30*1000; // 6 hours in milliseconds
-    const epochRounded = secondsBuste * Math.ceil(getTimestamp() / secondsBuste);
-    const cdnEndpoint = data.useStaging ? 'https://staging.bgmin.cdn.billygrace.com' : 'https://bgmin.cdn.billygrace.com';
-    const scriptUrl = cdnEndpoint + '?t=' + epochRounded + '&v=0.2.0';
+// CDN already loaded -- call .process directly, bypassing the stub
+if (processFunc && getType(processFunc) === 'function') {
+  debugLog('CDN already loaded, calling .process directly');
+  callInWindow(billyFunctionName + '.process', 'init', billyPixId, extraInitOptions);
+  if (data.noPageloadEvent === false) {
+    if (data.pageloadEventID) {
+      callInWindow(billyFunctionName + '.process', 'event', 'pageload', {event_id: data.pageloadEventID});
+    } else {
+      callInWindow(billyFunctionName + '.process', 'event', 'pageload');
+    }
+  }
+} 
+// CDN not loaded yet -- write events directly into the queue
+else {
+  debugLog('CDN not loaded yet, writing events to queue');
+  const currentQueue = copyFromWindow(billyFunctionName + '.queue');
+  if (currentQueue && getType(currentQueue) === 'array') {
 
-    // Check permissions for script injection
-    if (!queryPermission('inject_script', scriptUrl)) {
-      log('[BG Event Tag] Error: Permission denied to inject script from ' + scriptUrl);
-      return data.gtmOnFailure();
+    // Add init and initial pageload event to the queue (if required)
+    currentQueue.push(['init', billyPixId, extraInitOptions]);
+    if (data.noPageloadEvent === false) {
+      if (data.pageloadEventID) {
+        currentQueue.push(['event', 'pageload', {event_id: data.pageloadEventID}]);
+      } else {
+        currentQueue.push(['event', 'pageload']);
+      }
     }
 
-    // Inject the BillyPix script
-    injectScript(scriptUrl, onScriptLoadedAndFireEvent, data.gtmOnFailure, scriptUrl);  
+    // Need to overwrite the queue with the new one as its just a copy of the original
+    setInWindow(billyFunctionName + '.queue', currentQueue, true);
+  }else{
+    debugLog('Queu does not exist, something went wrong');
+  }
 }
+
+function onScriptLoaded() {
+  debugLog('Script loaded successfully');
+  return data.gtmOnSuccess();
+}
+
+function onScriptFailed() {
+  log('Error: Billy Grace Pixel script failed to load from ' + scriptUrl);
+  return data.gtmOnFailure();
+}
+
+debugLog('Loading script from: ' + scriptUrl);
+injectScript(scriptUrl, onScriptLoaded, onScriptFailed, scriptUrl);

--- a/template.js
+++ b/template.js
@@ -163,7 +163,7 @@ else {
     // Need to overwrite the queue with the new one as its just a copy of the original
     setInWindow(billyFunctionName + '.queue', currentQueue, true);
   }else{
-    debugLog('Queu does not exist, something went wrong');
+    debugLog('Queue does not exist, something went wrong');
   }
 }
 

--- a/template.js
+++ b/template.js
@@ -44,7 +44,7 @@ function debugLog(message) {
 }
 // For all error messages the end user should see
 function errorLog(message) {
-   log('[BG Conf Tag] Error: ', message);
+   log('[BG Conf Tag] Error:', message);
 }
 
 

--- a/template.tpl
+++ b/template.tpl
@@ -146,10 +146,10 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 const log = require('logToConsole');
 const JSON = require('JSON');
 const setInWindow = require('setInWindow');
-const createQueue = require('createQueue');
 const getTimestamp = require('getTimestamp');
 const Math = require('Math');
 const injectScript = require('injectScript');
+const callInWindow = require('callInWindow');
 const copyFromWindow = require('copyFromWindow');
 const getType = require('getType');
 const getContainerVersion = require('getContainerVersion');
@@ -186,18 +186,22 @@ function debugLog(message) {
     log('[BG Conf Tag]', message);
   }
 }
+// For all error messages the end user should see
+function errorLog(message) {
+   log('[BG Conf Tag] Error:', message);
+}
+
 
 // Tracking ID needs to be set
 if (getType(billyPixId) === 'undefined') {
-  log('Error: Billy Grace Pixel not configured correctly. No Tracking ID is set.');
+  errorLog('Billy Grace Pixel not configured correctly. No Tracking ID is set.');
   return data.gtmOnFailure();
 }
 
 // Check permission to inject the script
 if (!queryPermission('inject_script', scriptUrl)) {
-  log('Error: Permission denied to inject Billy Grace Pixel script from', scriptUrl);
-  data.gtmOnFailure();
-  return;
+  errorLog('Permission denied to inject Billy Grace Pixel script from: ' + scriptUrl);
+  return data.gtmOnFailure();
 }
 
 
@@ -235,6 +239,9 @@ function addMainFunctionToWindow() {
       // Add to queu for later processing when remote js arrives
       if (queue && getType(queue) === 'array') {
         queue.push(args);
+
+        // Need to overwrite the queue with the new one as its just a copy of the original
+        setInWindow(billyFunctionName + '.queue', queue, true);
       } else {
         // If queue isn't available, initialize it first
         setInWindow(billyFunctionName + '.queue', [args], true);
@@ -254,7 +261,17 @@ function addMainFunctionToWindow() {
   
 }
 
-// Check if BillyPix already exists - same as original snippet's first check
+function onScriptLoaded() {
+  debugLog('Script loaded successfully');
+  return data.gtmOnSuccess();
+}
+
+function onScriptFailed() {
+  debugLog('Error: Billy Grace Pixel script failed to load from ' + scriptUrl, true);
+  return data.gtmOnFailure();
+}
+
+// Check if BillyPix already exists, mimics the original snippet's first check
 const existingFunc = copyFromWindow(billyFunctionName);
 if (!existingFunc) {
   addMainFunctionToWindow();
@@ -262,58 +279,66 @@ if (!existingFunc) {
   debugLog(billyFunctionName + ' already exists in window, using existing implementation');
 }
 
-/**
- * Callback function when script is successfully loaded
- * Initializes the pixel and triggers page view if configured
- */
-function onScriptLoaded() {
-  // Get the function again to ensure we have latest reference
-  const BillyPix = copyFromWindow(billyFunctionName);
+// Build init options
+let extraInitOptions = {debug: isGtmDebugSession};
+if (getType(data.overrideCookiedomain) !== 'undefined') {
+  extraInitOptions.cookie_domain = data.overrideCookiedomain;
+}
 
-  if (!BillyPix) {
-    log('Error: ' + billyFunctionName + ' not found after script load');
-    return data.gtmOnFailure();
-  }
-  
-  // Extra options for this pixel session
-  let extraInitOptions = {debug: isGtmDebugSession};
-    
-  // Optionally check the cookie domain needs to be overwritten
-  if (getType(data.overrideCookiedomain) !== 'undefined') {
-    extraInitOptions.cookie_domain = data.overrideCookiedomain;
-  }
+// Check if the CDN bundle is already loaded (e.g. by the event tag)
+const processFunc = copyFromWindow(billyFunctionName + '.process');
 
-  // Initialize BillyPix with the tracking ID
-  BillyPix('init', billyPixId, extraInitOptions);
+
+// CDN already loaded: call .process directly, bypassing the stub
+if (processFunc && getType(processFunc) === 'function') {
+  debugLog('CDN already loaded, calling .process directly');
   
-  // By default unchecked, meaning we send out the pageload event
-  if (data.noPageloadEvent === false){
-     
-    // Event id is used for de-duplication
-    if (data.pageloadEventID){
-       BillyPix('event', 'pageload', {event_id: data.pageloadEventID});
-    }else{
-       BillyPix('event', 'pageload');
+  // Setup the initialiazation with any given extra options
+  callInWindow(billyFunctionName + '.process', 'init', billyPixId, extraInitOptions);
+
+  // Make sure the pageload event gets triggered 
+  if (data.noPageloadEvent === false) {
+    if (data.pageloadEventID) {
+      callInWindow(billyFunctionName + '.process', 'event', 'pageload', {event_id: data.pageloadEventID});
+    } else {
+      callInWindow(billyFunctionName + '.process', 'event', 'pageload');
     }
   }
-  
-  // Finish with the success handler to close this function
+
+  // Complete the tag as required events have been fired directly at .process 
   return data.gtmOnSuccess();
+} 
+// CDN not loaded yet: write events directly into the queue
+else {
+
+  // Grab a copy (non reference) from an existing queue object to add to 
+  const currentQueue = copyFromWindow(billyFunctionName + '.queue');
+  
+  if (currentQueue && getType(currentQueue) === 'array') {
+    debugLog('CDN not loaded yet, writing events to queue');
+
+    // Add init and initial pageload event to the queue (if required)
+    currentQueue.push(['init', billyPixId, extraInitOptions]);
+    
+    // Make sure the pageload event gets triggered 
+    if (data.noPageloadEvent === false) {
+      if (data.pageloadEventID) {
+        currentQueue.push(['event', 'pageload', {event_id: data.pageloadEventID}]);
+      } else {
+        currentQueue.push(['event', 'pageload']);
+      }
+    }
+
+    // Need to overwrite the queue with the new one as its just a copy of the original
+    setInWindow(billyFunctionName + '.queue', currentQueue, true);
+  }else{
+    errorLog('Queue does not exist so can\'t add "pageload" event to queue..');
+  }
+
+  // Load the script into the website and complete the tag when its loaded
+  debugLog('Loading script from: ' + scriptUrl);
+  injectScript(scriptUrl, onScriptLoaded, onScriptFailed, scriptUrl);
 }
-
-/**
- * Callback function when script fails to load
- */
-function onScriptFailed() {
-  log('Error: Billy Grace Pixel script failed to load from ' + scriptUrl);
-  return data.gtmOnFailure();
-}
-
-// Log script loading
-debugLog('Loading script from: ' + scriptUrl);
-
-// Inject the script
-injectScript(scriptUrl, onScriptLoaded, onScriptFailed, scriptUrl);
 
 
 ___WEB_PERMISSIONS___
@@ -571,6 +596,84 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "StagBillyPix.t"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "BillyPix.process"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "key"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  },
+                  {
+                    "type": 1,
+                    "string": "execute"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "StagBillyPix.process"
                   },
                   {
                     "type": 8,


### PR DESCRIPTION
* Re-ordered main logic to account for sequencing issues
* Main paths to take into consideration it needs to account for due to people messing up their sequencing:
    - Normal flow (conf first, CDN not loaded): conf creates stub, writes init/pageload directly into the queue via setInWindow, injectScript loads CDN, queue loop in setup.js processes them
    - Broken flow, CDN already loaded (event tag loaded it): .process exists, callInWindow calls it directly, events fire immediately
    - Broken flow, CDN still loading (event tag started loading it): .process doesn't exist, events written to queue, CDN finishes loading, queue loop processes them
    - Event tag happy path (unchanged): stub's .process check routes to .process, event fires
    - Event tag fallback (unchanged): callback runs after CDN loads, .process exists, init + event fire